### PR TITLE
feat: `build.rs` fo sp1 proof before eq-server build to genereate ELF 

### DIFF
--- a/runner-keccak-inclusion/build.rs
+++ b/runner-keccak-inclusion/build.rs
@@ -1,11 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Protobuff generation
-    tonic_build::configure()
-        .build_server(true)
-        .build_client(true)
-        .out_dir("src/generated")
-        .compile_protos(&["proto/eqservice.proto"], &["proto/"])?;
-
     // SP1 ELF/Program build
     let sp1_program_crate_path = "../program-keccak-inclusion";
     let sp1_elf_path = "../target/release/eq-program-keccak-inclusion";

--- a/runner-keccak-inclusion/src/main.rs
+++ b/runner-keccak-inclusion/src/main.rs
@@ -3,7 +3,7 @@ use std::fs;
 use eq_common::KeccakInclusionToDataRootProofInput;
 use celestia_types::nmt::NamespaceProof;
 
-const KECCAK_INCLUSION_ELF: &[u8] = include_bytes!("../../target/elf-compilation/riscv32im-succinct-zkvm-elf/release/eq-program-keccak-inclusion");
+const KECCAK_INCLUSION_ELF: &[u8] = include_bytes!("../../target/release/eq-program-keccak-inclusion");
 
 
 fn main() {

--- a/service/build.rs
+++ b/service/build.rs
@@ -1,11 +1,29 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Protobuff generation
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
         .out_dir("src/generated")
-        .compile_protos(
-            &["proto/eqservice.proto"],
-            &["proto/"]
-        )?;
+        .compile_protos(&["proto/eqservice.proto"], &["proto/"])?;
+
+    // SP1 ELF build
+    let sp1_program_path = "../program-keccak-inclusion";
+
+    // Run `cargo build` for the other crate
+    let sp1_build_status = std::process::Command::new("cargo")
+        .arg("build")
+        .arg("--release") // Optionally build in release mode
+        .current_dir(sp1_program_path)
+        .status()
+        .expect("Failed to execute cargo build for the other crate");
+
+    // Check if the command succeeded
+    if !sp1_build_status.success() {
+        panic!("Building sp1 proof failed!");
+    }
+
+    // Optionally, emit build artifacts to Cargo
+    println!("cargo:rerun-if-changed={}", sp1_program_path);
+
     Ok(())
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -26,7 +26,7 @@ use sp1_sdk::{ProverClient, SP1Proof, SP1ProofWithPublicValues, SP1Stdin, Prover
 use eq_common::{KeccakInclusionToDataRootProofInput, create_inclusion_proof_input};
 use serde::{Serialize, Deserialize};
 
-const KECCAK_INCLUSION_ELF: &[u8] = include_bytes!("../../target/elf-compilation/riscv32im-succinct-zkvm-elf/release/eq-program-keccak-inclusion");
+const KECCAK_INCLUSION_ELF: &[u8] = include_bytes!("../../target/release/eq-program-keccak-inclusion");
 
 #[derive(Serialize, Deserialize)]
 pub struct Job {


### PR DESCRIPTION
Experimenting with ways to automate ELF generation, but this present attempt is a bit too hacky and fails if I manually remove `target` artifacts.

A better way would likely be a to [just](https://just.systems/) prepare & build w/ some scripting